### PR TITLE
Replaced NSBundle.mainBundle with bundleForClass:

### DIFF
--- a/src/SCRProfanityChecker.m
+++ b/src/SCRProfanityChecker.m
@@ -23,7 +23,7 @@
     static SCRProfanityChecker *_shared;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSString *filePath = [[NSBundle mainBundle] pathForResource:@"Profanity" ofType:@"txt"];
+        NSString *filePath = [[NSBundle bundleForClass:self] pathForResource:@"Profanity" ofType:@"txt"];
         _shared = [[SCRProfanityChecker alloc] initWithListFilePath:filePath];
     });
     return _shared;


### PR DESCRIPTION
A change like this should retain the previous behaviour (needs testing) but at the same time, allow this library to be used within Swift projects (that is, compiled as a framework).